### PR TITLE
Do not tap caskroom/cask

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,6 @@ function main() {
 
   echo "=== Installing Virtualbox..."
   if [ ! -e /Applications/VirtualBox.app ]; then
-    brew tap caskroom/cask
     brew cask install virtualbox
     echo "===> OK"
   else


### PR DESCRIPTION
Because of [the recent change made to homebrew](https://github.com/Homebrew/brew/pull/6525) I got the following error while running the install script:

```
Error: caskroom/cask was moved. Tap homebrew/cask-cask instead.
```


<details>
<summary>Full log</summary>

```
$ curl -sfSL https://github.com/dziemba/mobymac/raw/master/install.sh |bash -s bash 4096a
=========
 mobymac
=========

Creating docker v19.03.3 VM with 4096aMB RAM and bash shell integration

WARNING: this will uninstall docker4mac and destroy all existing docker data
Press CTRL-C to abort (sleeping for 5 seconds)

=== Uninstalling Docker for Mac (brew cask)...
docker
==> Uninstalling Cask docker
==> Removing launchctl service com.docker.helper
Password:
==> Removing launchctl service com.docker.vmnetd
==> Removing files:
/Library/PrivilegedHelperTools/com.docker.vmnetd
/private/var/tmp/com.docker.vmnetd.socket
/usr/local/bin/docker
/usr/local/bin/docker-compose
/usr/local/bin/docker-credential-osxkeychain
/usr/local/bin/docker-machine
/usr/local/bin/hyperkit
/usr/local/bin/notary
/usr/local/bin/vpnkit
==> Backing App 'Docker.app' up to '/usr/local/Caskroom/docker/2.1.0.3,38240/Doc
==> Removing App '/Applications/Docker.app'.
==> Purging files for version 2.1.0.3,38240 of Cask docker
===> OK

=== Uninstalling Docker for Mac (native)...
=== Not found - skipping

=== Installing Virtualbox...
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).
==> Updated Formulae
flyway          libsass         meson           ola             screenfetch
==> Deleted Formulae
protobuf@3.1                             supersonic

Error: caskroom/cask was moved. Tap homebrew/cask-cask instead.
```
</details>

In this PR, I just deleted the line that taps `caskroom/cask` as, in my understanding, it's now bundled with homebrew but let me know if this is not the case.
